### PR TITLE
feat: ShareButton 컴포넌트 구현 & GNB 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,8 +4,10 @@ const nextConfig = {
   // Configure `pageExtensions` to include MDX files
   pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
   // Optionally, add any other Next.js config below
+  output: 'export',
+  trailingSlash: true,
   images: {
-    loader: 'default', // 또는 'default'
+    unoptimized: true,
   },
 }
 module.exports = withMDX(nextConfig)

--- a/public/external-link.svg
+++ b/public/external-link.svg
@@ -1,0 +1,5 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 8.66691V12.6669C12.5 13.0205 12.3595 13.3597 12.1095 13.6097C11.8594 13.8598 11.5203 14.0002 11.1667 14.0002H3.83333C3.47971 14.0002 3.14057 13.8598 2.89052 13.6097C2.64048 13.3597 2.5 13.0205 2.5 12.6669V5.33358C2.5 4.97996 2.64048 4.64082 2.89052 4.39077C3.14057 4.14072 3.47971 4.00024 3.83333 4.00024H7.83333" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.5 2.00024H14.5V6.00024" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.1665 9.33358L14.4998 2.00024" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/design/[slug]/page.tsx
+++ b/src/app/design/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Markdown from 'react-markdown'
 import CodeBlock from '@/components/Code'
 import Pre from '@/components/Pre'
+import ShareButton from '@/components/ShareButton'
 import { findPostByType, getAllPosts } from '@/utils/posts'
 import { format } from 'date-fns'
 import Image from 'next/image'
@@ -85,6 +86,9 @@ export default async function Post({ params }: { params: { type: string; slug: s
           </Markdown>
         </div>
       </article>
+      <div className="border-t border-t-gray-300 py-14 text-center">
+        <ShareButton />
+      </div>
     </div>
   )
 }

--- a/src/app/tech/[slug]/page.tsx
+++ b/src/app/tech/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Markdown from 'react-markdown'
 import CodeBlock from '@/components/Code'
 import Pre from '@/components/Pre'
+import ShareButton from '@/components/ShareButton'
 import { findPostByType, getAllPosts } from '@/utils/posts'
 import { format } from 'date-fns'
 import Image from 'next/image'
@@ -44,7 +45,7 @@ export default async function Post({ params }: { params: { type: string; slug: s
   const updatedAt = format(new Date(date), 'yyyy년 MM월 dd일')
   return (
     <div className="mx-auto px-5 md:max-w-3xl">
-      <article>
+      <article className="mb-20">
         <header>
           <Image
             src={`/${thumbnail}`}
@@ -83,6 +84,9 @@ export default async function Post({ params }: { params: { type: string; slug: s
           </Markdown>
         </div>
       </article>
+      <div className="border-t border-t-gray-300 py-14 text-center">
+        <ShareButton />
+      </div>
     </div>
   )
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,20 +7,20 @@ const Footer = () => {
       <div className="mx-auto flex flex-col justify-between gap-y-6 px-5 py-16 md:max-w-3xl md:flex-row md:items-center md:py-20">
         <div className="flex flex-col">
           <div className="mb-2.5 flex items-center text-base leading-4">
-            <Image src="logo.svg" alt="FREEMED" width={111} height={17} className="mr-2" />
+            <Image src="/logo.svg" alt="FREEMED" width={111} height={17} className="mr-2" />
             Tech
           </div>
           <p className="text-xs">Copyright © 2024 FREEMED All Rights Reserved</p>
         </div>
         <div className="flex gap-4">
           <Link href="https://pf.kakao.com/_xbMsxou" target="_blank">
-            <Image src="kakaotalk.svg" alt="카카오톡 채널" width={30} height={30} />
+            <Image src="/kakaotalk.svg" alt="카카오톡 채널" width={30} height={30} />
           </Link>
           <Link href="https://www.instagram.com/freemed_official" target="_blank">
-            <Image src="instagram.svg" alt="인스타그램" width={30} height={30} />
+            <Image src="/instagram.svg" alt="인스타그램" width={30} height={30} />
           </Link>
           <Link href="https://blog.naver.com/freemedorg" target="_blank">
-            <Image src="blog.svg" alt="블로그" width={30} height={30} />
+            <Image src="/blog.svg" alt="블로그" width={30} height={30} />
           </Link>
         </div>
       </div>

--- a/src/components/GNB.tsx
+++ b/src/components/GNB.tsx
@@ -30,7 +30,7 @@ const GNB = () => {
     <header className="fixed top-0 z-50 w-full border-b border-gray-200 bg-white">
       <nav className="mx-auto flex h-16 items-center justify-between px-5 font-neo md:px-20 lg:max-w-7xl">
         <h1>
-          <Link href="/" className="flex items-center text-base leading-4">
+          <Link href="/tech" className="flex items-center text-base leading-4">
             <Image src="logo.svg" alt="FREEMED" width={111} height={17} className="mr-2" />
             Tech
           </Link>
@@ -39,7 +39,7 @@ const GNB = () => {
           <Link
             href="/tech"
             className={`${
-              path === 'tech' &&
+              (path === 'tech' || path === '') &&
               'before:absolute before:bottom-[-8px] before:left-0 before:h-0.5 before:w-full before:bg-freemed-red before:content-[""]'
             } subTitle2 relative mx-3 px-px font-semibold`}
           >
@@ -72,7 +72,7 @@ const GNB = () => {
             className={`${isMobileOpen ? 'block' : 'hidden'} fixed left-0 top-0 h-full w-full bg-black/[0.6] md:hidden`}
           />
           <div
-            className={`${isMobileOpen ? 'right-0' : 'right-[-264px]'} fixed top-0 flex h-full w-[264px] flex-col justify-between overflow-y-scroll bg-white pb-4 pt-7 transition-all`}
+            className={`${isMobileOpen ? 'right-0' : 'right-[-264px]'} fixed top-0 flex h-full w-[264px] flex-col justify-between overflow-y-scroll bg-white pb-4 pt-7 transition-all duration-300`}
           >
             <div className="flex flex-col items-end">
               <button onClick={() => setIsMobileOpen(false)} className="mb-10 mr-5">
@@ -80,7 +80,7 @@ const GNB = () => {
               </button>
               <Link
                 href="/tech"
-                className={`${path === 'tech' && 'text-freemed-red'} subTitle2 w-full border-b border-gray-200 py-4 pl-5 font-semibold`}
+                className={`${(path === 'tech' || path === '') && 'text-freemed-red'} subTitle2 w-full border-b border-gray-200 py-4 pl-5 font-semibold`}
               >
                 개발
               </Link>

--- a/src/components/GNB.tsx
+++ b/src/components/GNB.tsx
@@ -39,7 +39,7 @@ const GNB = () => {
       <nav className="mx-auto flex h-16 items-center justify-between px-5 font-neo md:px-20 lg:max-w-7xl">
         <h1>
           <Link href="/tech" className="flex items-center text-base leading-4">
-            <Image src="logo.svg" alt="FREEMED" width={111} height={17} className="mr-2" />
+            <Image src="/logo.svg" alt="FREEMED" width={111} height={17} className="mr-2" />
             Tech
           </Link>
         </h1>
@@ -68,12 +68,12 @@ const GNB = () => {
             className="subTitle2 ml-5 flex items-center font-normal text-gray-700"
           >
             프리메드 홈페이지
-            <Image src="arrow-up-right.svg" alt="바로가기" width={24} height={24} />
+            <Image src="/arrow-up-right.svg" alt="바로가기" width={24} height={24} />
           </Link>
         </div>
         <div className="md:hidden">
           <button onClick={handleOpen} className="flex md:hidden">
-            <Image src="menu-bar.svg" alt="열기" width={32} height={32} />
+            <Image src="/menu-bar.svg" alt="열기" width={32} height={32} />
           </button>
           <div
             onClick={handleClose}
@@ -84,7 +84,7 @@ const GNB = () => {
           >
             <div className="flex flex-col items-end">
               <button onClick={handleClose} className="mb-10 mr-5">
-                <Image src="close.svg" alt="닫기" width={24} height={24} />
+                <Image src="/close.svg" alt="닫기" width={24} height={24} />
               </button>
               <Link
                 href="/tech"
@@ -106,7 +106,7 @@ const GNB = () => {
               target="_blank"
               className="subTitle2 flex items-center pl-5 font-normal text-gray-700"
             >
-              프리메드 홈페이지 <Image src="arrow-up-right.svg" alt="바로가기" width={24} height={24} />
+              프리메드 홈페이지 <Image src="/arrow-up-right.svg" alt="바로가기" width={24} height={24} />
             </Link>
           </div>
         </div>

--- a/src/components/GNB.tsx
+++ b/src/components/GNB.tsx
@@ -26,6 +26,14 @@ const GNB = () => {
     }
   }, [isMobileOpen])
 
+  const handleOpen = () => {
+    setIsMobileOpen(true)
+  }
+
+  const handleClose = () => {
+    setIsMobileOpen(false)
+  }
+
   return (
     <header className="fixed top-0 z-50 w-full border-b border-gray-200 bg-white">
       <nav className="mx-auto flex h-16 items-center justify-between px-5 font-neo md:px-20 lg:max-w-7xl">
@@ -64,29 +72,31 @@ const GNB = () => {
           </Link>
         </div>
         <div className="md:hidden">
-          <button onClick={() => setIsMobileOpen(true)} className="flex md:hidden">
+          <button onClick={handleOpen} className="flex md:hidden">
             <Image src="menu-bar.svg" alt="열기" width={32} height={32} />
           </button>
           <div
-            onClick={() => setIsMobileOpen(false)}
+            onClick={handleClose}
             className={`${isMobileOpen ? 'block' : 'hidden'} fixed left-0 top-0 h-full w-full bg-black/[0.6] md:hidden`}
           />
           <div
             className={`${isMobileOpen ? 'right-0' : 'right-[-264px]'} fixed top-0 flex h-full w-[264px] flex-col justify-between overflow-y-scroll bg-white pb-4 pt-7 transition-all duration-300`}
           >
             <div className="flex flex-col items-end">
-              <button onClick={() => setIsMobileOpen(false)} className="mb-10 mr-5">
+              <button onClick={handleClose} className="mb-10 mr-5">
                 <Image src="close.svg" alt="닫기" width={24} height={24} />
               </button>
               <Link
                 href="/tech"
                 className={`${(path === 'tech' || path === '') && 'text-freemed-red'} subTitle2 w-full border-b border-gray-200 py-4 pl-5 font-semibold`}
+                onClick={handleClose}
               >
                 개발
               </Link>
               <Link
                 href="/design"
                 className={`${path === 'design' && 'text-freemed-red'} subTitle2 w-full border-b border-gray-200 py-4 pl-5 font-semibold`}
+                onClick={handleClose}
               >
                 디자인
               </Link>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import Image from 'next/image'
+import { usePathname } from 'next/navigation'
+
+const ShareButton = () => {
+  const pathname = usePathname()
+
+  const handleCopyClipBoard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      alert('링크가 복사되었습니다.')
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  return (
+    <button
+      className="subTitle2 inline-flex items-center rounded-md bg-freemed-red px-6 py-2 text-white"
+      onClick={() => handleCopyClipBoard(`https://tech.freemed.or.kr${pathname}`)}
+    >
+      <Image src="external-link.svg" alt="" width={16} height={16} className="mr-2" />
+      공유하기
+    </button>
+  )
+}
+
+export default ShareButton

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -20,7 +20,7 @@ const ShareButton = () => {
       className="subTitle2 inline-flex items-center rounded-md bg-freemed-red px-6 py-2 text-white"
       onClick={() => handleCopyClipBoard(`https://tech.freemed.or.kr${pathname}`)}
     >
-      <Image src="external-link.svg" alt="" width={16} height={16} className="mr-2" />
+      <Image src="/external-link.svg" alt="" width={16} height={16} className="mr-2" />
       공유하기
     </button>
   )


### PR DESCRIPTION
## #️⃣ 이슈 번호
- close #11 

## 💡 구현 내용
- 공유하기 버튼을 구현했습니다.
- 모바일에서 GNB가 안닫히는 버그를 수정했습니다.
- nextConfig를 수정했습니다.
```js
  output: 'export', // 정적 페이지
  trailingSlash: true, // output: 'export' 옵션으로 /index.html 경로로 추출됨. 페이지 이동 시 맨 뒤에 / 붙여서 리다이렉트 필요
  images: {
    unoptimized: true, // 이미지 최적화 X
  },
```

## 📢 PR Point

## 📸 스크린샷
<img width="739" alt="techblog_ShareButton" src="https://github.com/freemed-it/techblog/assets/49032882/fcbbf8fd-a55c-406d-96a1-b81df9a77f14">