### PR TITLE
feat: 페이지 라우팅 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,8 +30,8 @@
 @layer components {
   .heading {
     font-weight: bold;
-    font-size: 32px;
-    line-height: 42px;
+    font-size: 24px;
+    line-height: 32px;
   }
 
   .subTitle1 {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 import Header from '@/components/Header'
 import PostCard from '@/components/PostCard'
-import { getAllPostsInDirectory } from '@/utils/posts'
+import { getAllPosts, getAllPostsInDirectory } from '@/utils/posts'
 
 export default async function Main() {
-  const posts = getAllPostsInDirectory('tech')
+  const posts = await getAllPosts()
   return (
     <>
       <Header />

--- a/src/components/GNB.tsx
+++ b/src/components/GNB.tsx
@@ -38,7 +38,7 @@ const GNB = () => {
     <header className="fixed top-0 z-50 w-full border-b border-gray-200 bg-white">
       <nav className="mx-auto flex h-16 items-center justify-between px-5 font-neo md:px-20 lg:max-w-7xl">
         <h1>
-          <Link href="/tech" className="flex items-center text-base leading-4">
+          <Link href="/" className="flex items-center text-base leading-4">
             <Image src="/logo.svg" alt="FREEMED" width={111} height={17} className="mr-2" />
             Tech
           </Link>
@@ -47,7 +47,7 @@ const GNB = () => {
           <Link
             href="/tech"
             className={`${
-              (path === 'tech' || path === '') &&
+              path === 'tech' &&
               'before:absolute before:bottom-[-8px] before:left-0 before:h-0.5 before:w-full before:bg-freemed-red before:content-[""]'
             } subTitle2 relative mx-3 px-px font-semibold`}
           >
@@ -88,7 +88,7 @@ const GNB = () => {
               </button>
               <Link
                 href="/tech"
-                className={`${(path === 'tech' || path === '') && 'text-freemed-red'} subTitle2 w-full border-b border-gray-200 py-4 pl-5 font-semibold`}
+                className={`${path === 'tech' && 'text-freemed-red'} subTitle2 w-full border-b border-gray-200 py-4 pl-5 font-semibold`}
                 onClick={handleClose}
               >
                 개발

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,11 +6,14 @@ const Header = () => {
   const path = usePathname().split('/')[1]
 
   return (
-    <header className="heading flex h-[600px] flex-col items-center bg-[url('/header-mobile.png')] bg-contain bg-center bg-no-repeat pt-44 text-center font-neo md:h-[420px] md:bg-[url('/header-pc.png')] md:bg-cover">
+    <header className="flex h-[600px] flex-col items-center bg-[url('/header-mobile.png')] bg-contain bg-center bg-no-repeat pt-44 text-center font-neo text-3xl font-bold md:h-[420px] md:bg-[url('/header-pc.png')] md:bg-cover">
       <h2>프리메드 기술 블로그</h2>
-      <span className="subTitle2 mt-5 rounded-full bg-freemed-red px-6 py-2 text-white">
-        {path === 'design' ? '디자인' : '개발'}
-      </span>
+
+      {path !== '' && (
+        <span className="subTitle2 mt-5 rounded-full bg-freemed-red px-6 py-2 text-white">
+          {path === 'design' ? '디자인' : '개발'}
+        </span>
+      )}
     </header>
   )
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -40,9 +40,9 @@ export default function PostCard({ post }: { post: Post }) {
             href={`/${slug}`}
             className="align-center flex-col justify-between transition ease-in-out hover:text-freemed-red md:order-1 md:mt-0"
           >
-            <h1 className="heading mb-3.5 inline-block">{title}</h1>
+            <h2 className="heading mb-2 inline-block">{title}</h2>
             <div>
-              <p className="body1 mb-3 block text-gray-800">{description}</p>
+              <p className="body1 mb-2 block text-gray-800">{description}</p>
               <time className="body2 text-gray-500" dateTime={updatedAt}>
                 {updatedAt}
               </time>

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 const Tag = ({ text }: { text: string }) => {
   return (
     <div className="mt-4 md:mt-0">
-      <div className="mb-2 mr-2 inline-block rounded bg-gray-50 p-2 dark:bg-gray-800">
+      <div className="mb-2 mr-2 inline-block rounded bg-gray-50 px-3 py-1 dark:bg-gray-800">
         <Link href={`/`}>
           <span className="body1">#{text}</span>
         </Link>

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -13,13 +13,18 @@ export async function findPostByType(type: string, slug: string) {
   return posts.find(post => post.fields.slug === slugs)
 }
 
-export async function getAllPosts(): Promise<Array<Post>> {
-  const postsDirectories = ['tech', 'design'] // Specify the folders
+export async function getAllPosts() {
+  const postsDirectories = ['tech', 'design']
   const allPosts = postsDirectories.flatMap(getAllPostsInDirectory)
-  return allPosts
+
+  const sortedAllPosts = allPosts.sort(
+    (a, b) => new Date(b.frontMatter.date).getTime() - new Date(a.frontMatter.date).getTime()
+  )
+
+  return sortedAllPosts
 }
 
-export function getAllPostsInDirectory(directory: string): Post[] {
+export function getAllPostsInDirectory(directory: string) {
   const POST_PATH = `${process.cwd()}${DIR_REPLACE_STRING}/${directory}`
   const files = sync(`${POST_PATH}/*.md*`).reverse()
 
@@ -45,7 +50,7 @@ export function getAllPostsInDirectory(directory: string): Post[] {
           fields: {
             slug,
           },
-          path: filePath, // Store the full file path if needed
+          path: filePath,
           slug: '',
           type: '',
           title: '',


### PR DESCRIPTION
## #️⃣ 이슈 번호
- close #24 

## 💡 구현 내용
- 각 페이지 라우팅을 아래와 같이 변경해주었습니다.
   - `/`: 개발, 디자인 전체 포스팅
   - `/tech`: 개발 포스팅
   - `/design`: 디자인 포스팅
- 전체 포스팅 불러올때 개발,디자인 상관없이 날짜순(최신순)으로 정렬하도록 구현하였습니다.


## 📢 PR Point

## 📸 스크린샷
![기술블로그_페이지 라우팅_1](https://github.com/freemed-it/techblog/assets/98146849/b78a5eb3-b388-478d-bf73-ae85c2fafa16)
![기술블로그_페이지 라우팅_2](https://github.com/freemed-it/techblog/assets/98146849/a7b015c8-660a-48e4-8613-e14dbb338861)
